### PR TITLE
Resolves #3

### DIFF
--- a/lib/edit_in_place/builder.rb
+++ b/lib/edit_in_place/builder.rb
@@ -71,6 +71,15 @@ module EditInPlace
       type.render(*args)
     end
 
+    def scoped(field_options = {})
+      field_options = FieldOptions.new(field_options) unless field_options.is_a? FieldOptions
+
+      scoped_builder = dup
+      scoped_builder.config.field_options.merge!(field_options)
+
+      yield scoped_builder
+    end
+
     private
 
     # Ensures that the first argument in the given list of arguments is a valid, appropriate

--- a/lib/edit_in_place/builder.rb
+++ b/lib/edit_in_place/builder.rb
@@ -23,6 +23,14 @@ module EditInPlace
       @config = EditInPlace.config.dup
     end
 
+    # Creates a deep copy of this {Builder} that can be safely modified.
+    # @return [Builder] a deep copy of this {Builder}.
+    def dup
+      b = Builder.new
+      b.config = config.dup
+      b
+    end
+
     # Configures this {Builder} by yielding its configuration to the given block.
     # @yieldparam config [Configuration] the {Configuration} instance associated with this
     #   {Builder}.

--- a/spec/edit_in_place/builder_spec.rb
+++ b/spec/edit_in_place/builder_spec.rb
@@ -38,6 +38,26 @@ RSpec.describe EditInPlace::Builder do
     end
   end
 
+  describe '#dup' do
+    before do
+      builder.config.field_options.middlewares = ['example', :another]
+    end
+    let(:dup) { builder.dup }
+
+    it 'returns a different instance' do
+      expect(dup.object_id).not_to eq builder.object_id
+    end
+
+    it 'copies the config' do
+      expect(dup.config.field_options.middlewares).to eq ['example', :another]
+    end
+
+    it 'performs a deep copy of the config' do
+      actual = dup.config.field_options.middlewares[0].object_id
+      expect(actual).not_to eq builder.config.field_options.middlewares[0].object_id
+    end
+  end
+
   describe '#configure' do
     it 'yields the configuration' do
       builder.configure do |c|

--- a/spec/support/middleware_one.rb
+++ b/spec/support/middleware_one.rb
@@ -3,7 +3,7 @@
 require 'middlegem'
 
 class MiddlewareOne < Middlegem::Middleware
-  def call(options, input)
-    [options, "#{input}*ONE*"]
+  def call(options, input, *args)
+    [options, "#{input}*ONE*", *args]
   end
 end


### PR DESCRIPTION
Resolves Issue #3 by adding a `#scoped` method to `Builder` which creates a new, scoped Builder and yields it.