### PR TITLE
Resolves #9

### DIFF
--- a/lib/edit_in_place.rb
+++ b/lib/edit_in_place.rb
@@ -70,5 +70,6 @@ end
 
 require 'edit_in_place/invalid_field_type_error'
 require 'edit_in_place/unregistered_field_type_error'
+require 'edit_in_place/unregistered_middleware_error'
 require 'edit_in_place/invalid_registration_name_error'
 require 'edit_in_place/duplicate_registration_error'

--- a/lib/edit_in_place.rb
+++ b/lib/edit_in_place.rb
@@ -10,6 +10,7 @@ require 'edit_in_place/field_options'
 require 'edit_in_place/field_type'
 require 'edit_in_place/field_type_registrar'
 require 'edit_in_place/middleware_stack'
+require 'edit_in_place/middleware_registrar'
 
 # {EditInPlace} is a namespace that contains all the modules and classes of the edit_in_place
 # Rails gemified plugin.

--- a/lib/edit_in_place.rb
+++ b/lib/edit_in_place.rb
@@ -9,6 +9,7 @@ require 'edit_in_place/extended_builder'
 require 'edit_in_place/field_options'
 require 'edit_in_place/field_type'
 require 'edit_in_place/field_type_registrar'
+require 'edit_in_place/middleware_stack'
 
 # {EditInPlace} is a namespace that contains all the modules and classes of the edit_in_place
 # Rails gemified plugin.

--- a/lib/edit_in_place/builder.rb
+++ b/lib/edit_in_place/builder.rb
@@ -78,8 +78,7 @@ module EditInPlace
       inject_field_options!(args)
       args[0] = config.field_options.merge(args[0])
 
-      definition = Middlegem::ArrayDefinition.new(config.defined_middlewares)
-      stack = Middlegem::Stack.new(definition, middlewares: args[0].middlewares)
+      stack = MiddlewareStack.new(config.defined_middlewares, args[0].middlewares)
       args = stack.call(*args)
 
       type = evaluate_field_type(type)

--- a/lib/edit_in_place/builder.rb
+++ b/lib/edit_in_place/builder.rb
@@ -78,7 +78,9 @@ module EditInPlace
       inject_field_options!(args)
       args[0] = config.field_options.merge(args[0])
 
-      stack = MiddlewareStack.new(config.defined_middlewares, args[0].middlewares)
+      stack = MiddlewareStack.new(config.defined_middlewares,
+                                  args[0].middlewares,
+                                  config.registered_middlewares)
       args = stack.call(*args)
 
       type = evaluate_field_type(type)

--- a/lib/edit_in_place/configuration.rb
+++ b/lib/edit_in_place/configuration.rb
@@ -27,11 +27,17 @@ module EditInPlace
     # @return [Array] the array of defined middlewares.
     attr_accessor :defined_middlewares
 
+    # The {MiddlewareRegistrar} used to store the list of registered middlewares.
+    # @return [MiddlewareRegistrar] the {MiddlewareRegistrar} that stores the list of registered
+    #   middlewares.
+    attr_accessor :registered_middlewares
+
     # Creates a new, default instance of {Configuration}.
     def initialize
       @field_types = FieldTypeRegistrar.new
       @field_options = FieldOptions.new(mode: DEFAULT_MODE)
       @defined_middlewares = []
+      @registered_middlewares = MiddlewareRegistrar.new
     end
 
     # Creates a deep copy of this {Configuration} that can be safely modified.
@@ -42,6 +48,7 @@ module EditInPlace
       c.field_options = field_options.dup
       # Note that this is purposely NOT a deep copy---it doesn't make sense to duplicate classes.
       c.defined_middlewares = defined_middlewares.dup
+      c.registered_middlewares = registered_middlewares.dup
       c
     end
   end

--- a/lib/edit_in_place/middleware_registrar.rb
+++ b/lib/edit_in_place/middleware_registrar.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 module EditInPlace
-  # {MiddlewareRegistrar] is a subclass of {Registrar] that only allows middleware objects (as
-  # defined by {Middlegem::Middleware.valid?}) to be registered.
+  # {MiddlewareRegistrar} is a subclass of {Registrar} that only allows middleware objects (as
+  # defined by +Middlegem::Middleware.valid?+) to be registered.
   #
   # @author Jacob Lockard
   # @since 0.2.0
   class MiddlewareRegistrar < Registrar
     protected
 
-    # Adds to the default `validate_registration!` implementation by ensuring that only
-    # middleware objects (as defined by {Middlegem::Middleware.valid?}) can be registered.
+    # Adds to the default +validate_registration!+ implementation by ensuring that only
+    # middleware objects (as defined by +Middlegem::Middleware.valid?+) can be registered.
     def validate_registration!(name, middleware)
       super
       raise Middlegem::InvalidMiddlewareError unless Middlegem::Middleware.valid?(middleware)

--- a/lib/edit_in_place/middleware_registrar.rb
+++ b/lib/edit_in_place/middleware_registrar.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module EditInPlace
+  # {MiddlewareRegistrar] is a subclass of {Registrar] that only allows middleware objects (as
+  # defined by {Middlegem::Middleware.valid?}) to be registered.
+  #
+  # @author Jacob Lockard
+  # @since 0.2.0
+  class MiddlewareRegistrar < Registrar
+    protected
+
+    # Adds to the default `validate_registration!` implementation by ensuring that only
+    # middleware objects (as defined by {Middlegem::Middleware.valid?}) can be registered.
+    def validate_registration!(name, middleware)
+      super
+      raise Middlegem::InvalidMiddlewareError unless Middlegem::Middleware.valid?(middleware)
+    end
+  end
+end

--- a/lib/edit_in_place/middleware_stack.rb
+++ b/lib/edit_in_place/middleware_stack.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'middlegem'
+
+module EditInPlace
+  # {MiddlewareStack} is a class that is capable of applying the given array of middlewares to
+  # a list of input arguments, given an array of defined middlewares. It uses +middlegem+.
+  #
+  # @author Jacob Lockard
+  # @since 0.2.0
+  class MiddlewareStack
+    # The array of defined middleware classes, in the order they should be run.
+    # @return [Array] the array of defined middleware classes.
+    attr_reader :defined_middlewares
+
+    # The array of middlewares to be applied.
+    # @return [Array] the middlewares.
+    attr_reader :middlewares
+
+    # Creates a new instance of {MiddlewareStack} with the given defined middleware classes and
+    # list of middlewares.
+    # @param defined_middlewares [Array] the array of defined middleware classes.
+    # @param middlewares [Array] the array of middlewares to apply.
+    def initialize(defined_middlewares, middlewares)
+      @defined_middlewares = defined_middlewares
+      @middlewares = middlewares
+    end
+
+    # Applies the list of middlewares to the given input arguments.
+    # @input [Array] the argument list to transform.
+    # @return [Array] the transformed argument list.
+    def call(*args)
+      definition = Middlegem::ArrayDefinition.new(defined_middlewares)
+      stack = Middlegem::Stack.new(definition, middlewares: middlewares)
+      stack.call(*args)
+    end
+  end
+end

--- a/lib/edit_in_place/middleware_stack.rb
+++ b/lib/edit_in_place/middleware_stack.rb
@@ -27,7 +27,7 @@ module EditInPlace
     end
 
     # Applies the list of middlewares to the given input arguments.
-    # @input [Array] the argument list to transform.
+    # @param args [Array] the argument list to transform.
     # @return [Array] the transformed argument list.
     def call(*args)
       definition = Middlegem::ArrayDefinition.new(defined_middlewares)

--- a/lib/edit_in_place/unregistered_middleware_error.rb
+++ b/lib/edit_in_place/unregistered_middleware_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module EditInPlace
+  # An error that occurs when no registered middlewares exist for the middleare name given.
+  class UnregisteredMiddlewareError < Error
+    # Creates a new instance of {UnregisteredMiddlewareError} with the given middleware name that
+    # caused the error.
+    # @param name [Symbol] the middleware that caused the error; used in the error message.
+    def initialize(name)
+      super("No middlewares are registered with the name '#{name}'")
+    end
+  end
+end

--- a/spec/edit_in_place/configuration_spec.rb
+++ b/spec/edit_in_place/configuration_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe EditInPlace::Configuration do
     it 'sets up an empty defined middlewares array' do
       expect(config.defined_middlewares).to eq []
     end
+
+    it 'sets up a blank MiddlewareRegistrar' do
+      expect(config.registered_middlewares.all).to be_empty
+    end
   end
 
   describe '#dup' do
@@ -36,6 +40,11 @@ RSpec.describe EditInPlace::Configuration do
         bool: TestFieldType.new('bool field')
       })
       config.defined_middlewares = [TestMiddleware.new]
+      config.registered_middlewares.register_all({
+        one: proc { },
+        two: proc { },
+        three: proc { }
+      })
     end
 
     let(:dup) { config.dup }
@@ -56,6 +65,11 @@ RSpec.describe EditInPlace::Configuration do
       expect(dup.defined_middlewares.object_id).not_to eq config.defined_middlewares.object_id
     end
 
+    it 'duplicates the MiddlewareRegistrar' do
+      actual = dup.registered_middlewares.object_id
+      expect(actual).not_to eq config.registered_middlewares.object_id
+    end
+
     it 'performs a deep copy of the FieldTypeRegistrar' do
       actual = dup.field_types.find(:text).object_id
       expect(actual).not_to eq config.field_types.find(:text).object_id
@@ -66,6 +80,11 @@ RSpec.describe EditInPlace::Configuration do
       expect(actual).to eq config.defined_middlewares[0].object_id
     end
 
+    it 'performs a deep copy of the MiddlewareRegistrar' do
+      actual = dup.registered_middlewares.find(:one).object_id
+      expect(actual).not_to eq config.registered_middlewares.find(:one).object_id
+    end
+
     it 'has a FieldTypeRegistrar that can be safely modified' do
       dup.field_types.register(:new, TestFieldType.new('NEW'))
       expect(config.field_types.find(:new)).to be_nil
@@ -74,6 +93,11 @@ RSpec.describe EditInPlace::Configuration do
     it 'has a defined middlewares array that can be safely modified' do
       dup.defined_middlewares << TestMiddleware.new
       expect(config.defined_middlewares.count).to eq 1
+    end
+
+    it 'has a MiddlewareRegistrar that can be safely modified' do
+      dup.registered_middlewares.register(:new, proc { })
+      expect(config.registered_middlewares.find(:new)).to be_nil
     end
   end
 end

--- a/spec/edit_in_place/configuration_spec.rb
+++ b/spec/edit_in_place/configuration_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe EditInPlace::Configuration do
       })
       config.defined_middlewares = [TestMiddleware.new]
       config.registered_middlewares.register_all({
-        one: proc { },
-        two: proc { },
-        three: proc { }
+        one: proc {},
+        two: proc {},
+        three: proc {}
       })
     end
 
@@ -96,7 +96,7 @@ RSpec.describe EditInPlace::Configuration do
     end
 
     it 'has a MiddlewareRegistrar that can be safely modified' do
-      dup.registered_middlewares.register(:new, proc { })
+      dup.registered_middlewares.register(:new, proc {})
       expect(config.registered_middlewares.find(:new)).to be_nil
     end
   end

--- a/spec/edit_in_place/middleware_registrar_spec.rb
+++ b/spec/edit_in_place/middleware_registrar_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EditInPlace::MiddlewareRegistrar do
+  let(:registrar) { described_class.new }
+
+  describe '$register' do
+    context 'with a non-middleware object' do
+      def register
+        registrar.register :capitalize, 'random bad object'
+      end
+
+      it 'raises an appropriate error' do
+        expect { register }.to raise_error Middlegem::InvalidMiddlewareError
+      end
+
+      it 'does not register the name' do
+        ignore { register }
+        expect(registrar.find(:capitalize)).to be_nil
+      end
+    end
+
+    context 'with a valid middleware object' do
+      before { registrar.register :capitalize, ->(input) { input.upcase } }
+
+      it 'registers it' do
+        expect(registrar.find(:capitalize).call('lower')).to eq 'LOWER'
+      end
+    end
+  end
+
+  describe '#register_all' do
+    context 'with one non-middleware object' do
+      def register
+        registrar.register_all({
+          capitalize: proc {},
+          bad: 'random object'
+        })
+      end
+
+      it 'raises an appropriate error' do
+        expect { register }.to raise_error Middlegem::InvalidMiddlewareError
+      end
+
+      it 'registers no middlewares' do
+        ignore { register }
+        expect(registrar.all).to be_empty
+      end
+    end
+  end
+end

--- a/spec/edit_in_place/middleware_stack_spec.rb
+++ b/spec/edit_in_place/middleware_stack_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EditInPlace::MiddlewareStack do
+  let(:defined) { [Proc] }
+  let(:registrar) { EditInPlace::MiddlewareRegistrar.new }
+  let(:stack) { described_class.new(defined, middlewares, registrar) }
+
+  describe '#call' do
+    context 'with an invalid middleware object' do
+      let(:middlewares) { [proc {}, proc {}, 'random bad object', proc {}] }
+
+      it 'raises an appropriate error' do
+        expected = Middlegem::InvalidMiddlewareError
+        expect { stack.call('random input') }.to raise_error expected
+      end
+    end
+
+    context 'with valid middleware objects' do
+      let(:middlewares) { [proc { |i| [i.upcase] }] }
+
+      it 'transforms the input correctly' do
+        expect(stack.call('lowercase')).to eq ['LOWERCASE']
+      end
+    end
+
+    context 'with a valid registered middleware name' do
+      before { registrar.register(:lowercase, proc { |i| [i.downcase] }) }
+
+      let(:middlewares) { [:lowercase] }
+
+      it 'transforms the input correctly' do
+        expect(stack.call('UPPERCASE')).to eq ['uppercase']
+      end
+    end
+
+    context 'with an unregistered middleware name' do
+      let(:middlewares) { [:unregistered] }
+
+      it 'raises an appropriate error' do
+        expect { stack.call('input') }.to raise_error EditInPlace::UnregisteredMiddlewareError
+      end
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -4,7 +4,7 @@
 module Helpers
   def ignore
     yield
-  rescue EditInPlace::Error
+  rescue EditInPlace::Error, Middlegem::Error
   end
 end
 # rubocop:enable Lint/SuppressedException


### PR DESCRIPTION
This pull request resolved Issue #9 by adding the ability to register middlewares with a symbol name and then use them by that name later.
