### PR TITLE
Fix #41

### DIFF
--- a/lib/edit_in_place/middleware_registrar.rb
+++ b/lib/edit_in_place/middleware_registrar.rb
@@ -15,7 +15,9 @@ module EditInPlace
     def validate_registration!(name, middleware)
       super
       unless Middlegem::Middleware.valid?(middleware) || middleware.instance_of?(Class)
-        raise Middlegem::InvalidMiddlewareError
+        raise Middlegem::InvalidMiddlewareError, <<~ERR
+          The middleware #{middleware.inspect} is not a valid middleware!
+        ERR
       end
     end
   end

--- a/lib/edit_in_place/middleware_wrapper.rb
+++ b/lib/edit_in_place/middleware_wrapper.rb
@@ -40,6 +40,13 @@ module EditInPlace
       base.call(*args)
     end
 
+    # Overrides +to_s+ to use the base middleware's string representation. This ensures that
+    # error messages are displayed properly.
+    # @return [String] the string representation of the base middleware.
+    def to_s
+      base.to_s
+    end
+
     private
 
     # Attempts to find a middleware registered with the given name in the middleware registrar.

--- a/spec/edit_in_place/builder_spec.rb
+++ b/spec/edit_in_place/builder_spec.rb
@@ -203,6 +203,27 @@ RSpec.describe EditInPlace::Builder do
         expect(actual).to eq 'Init: Test!, After: ARG*ONE*!TWO!$THREE$'
       end
     end
+
+    context 'with an unpermitted middleware' do
+      before do
+        EditInPlace.configure do |c|
+          c.defined_middlewares = []
+          c.field_options.middlewares << MiddlewareOne
+        end
+      end
+
+      def render
+        builder.field(TestFieldType.new('Test'), 'Arg')
+      end
+
+      it 'raises an appropriate error' do
+        expect { render }.to raise_error Middlegem::UnpermittedMiddlewareError
+      end
+
+      it 'properly represents the failed middleware' do
+        expect { render }.to raise_error(/#<MiddlewareOne:/)
+      end
+    end
   end
 
   describe '*_field' do

--- a/spec/edit_in_place/middleware_registrar_spec.rb
+++ b/spec/edit_in_place/middleware_registrar_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe EditInPlace::MiddlewareRegistrar do
         expect { register }.to raise_error Middlegem::InvalidMiddlewareError
       end
 
+      it 'properly represents the invalid object' do
+        expect { register }.to raise_error(/"random bad object"/)
+      end
+
       it 'does not register the name' do
         ignore { register }
         expect(registrar.find(:capitalize)).to be_nil


### PR DESCRIPTION
Fix Issue #41 by overriding `to_s` on `MiddlewareWrapper` so that error
message display the base middleware, not the wrapper.
